### PR TITLE
fix: use real newlines instead of literal \n in gh command body injection

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -359,7 +359,7 @@ function hasBodyFlag(command: string): boolean {
  * If --body/-b exists, append signature to its value.
  * If not, add --body flag with signature.
  */
-function addSignatureToGhCommand(command: string, signature: string, startIndex: number): string {
+function addSignatureToGhCommand(command: string, signature: string, startIndex: number, isPrDescription: boolean = false): string {
   const escapedSignature = escapeForShell(signature);
   const endIndex = findCommandEndIndex(command, startIndex);
 
@@ -375,7 +375,8 @@ function addSignatureToGhCommand(command: string, signature: string, startIndex:
 
     if (match) {
       const [fullMatch, flag, quote, content] = match;
-      const newContent = content.trimEnd() + "\n\n" + escapedSignature;
+      const separator = isPrDescription ? "\n\n" : "\\n\\n";
+      const newContent = content.trimEnd() + separator + escapedSignature;
       const newBody = `${flag} ${quote}${newContent}${quote}`;
       const modifiedPart = commandPart.replace(fullMatch, newBody);
       return beforeCommand + modifiedPart + afterCommand;
@@ -480,7 +481,9 @@ export const PRSignaturePlugin: Plugin = async () => {
           const ghMatch = command.match(/gh\s+(pr|issue)\s+(create|comment|review)\b/i);
 
           if (ghMatch && ghMatch.index !== undefined) {
-            output.args.command = addSignatureToGhCommand(command, signature, ghMatch.index);
+            const isPrDescription =
+              ghMatch[1]?.toLowerCase() === "pr" && ghMatch[2]?.toLowerCase() === "create";
+            output.args.command = addSignatureToGhCommand(command, signature, ghMatch.index, isPrDescription);
           }
         }
       }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -375,7 +375,7 @@ function addSignatureToGhCommand(command: string, signature: string, startIndex:
 
     if (match) {
       const [fullMatch, flag, quote, content] = match;
-      const newContent = content.trimEnd() + "\\n\\n" + escapedSignature;
+      const newContent = content.trimEnd() + "\n\n" + escapedSignature;
       const newBody = `${flag} ${quote}${newContent}${quote}`;
       const modifiedPart = commandPart.replace(fullMatch, newBody);
       return beforeCommand + modifiedPart + afterCommand;


### PR DESCRIPTION
## Problem

When the plugin intercepts a `gh pr create` bash command and appends the signature to an existing `--body` value, the separator between the original body and the signature was the 4-character literal string `\n\n` instead of real newline characters.

```ts
// before (broken)
const newContent = content.trimEnd() + "\\n\\n" + escapedSignature;
```

Bash does **not** interpret `\n` as a newline inside double-quoted strings, so `gh` received the literal characters `\n\n🤖 Generated with OpenCode...` — resulting in the broken description.

Git commits are unaffected — they append the signature via a separate `-m` flag with no separator involved.

## Fix

Use a real newline character as separator, scoped to `gh pr create` only. Other commands (`gh issue create`, `gh pr comment`, `gh issue comment`, `gh pr review`) and git commits retain their existing behaviour unchanged.

`addSignatureToGhCommand` receives a new `isPrDescription` flag (default `false`), set to `true` at the call site only when the matched command is `gh pr create`:

```ts
// after (fixed)
const separator = isPrDescription ? "\n\n" : "\\n\\n";
const newContent = content.trimEnd() + separator + escapedSignature;
```

A real newline inside a double-quoted shell argument is preserved literally by bash and passed correctly to `gh`.