### PR TITLE
chore: release v1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-pr-signature",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "description": "OpenCode plugin for automatically adding AI model signature to commits, Pull Requests, and Issues",
   "author": "arttttt <artembambalov1993@gmail.com>",


### PR DESCRIPTION
## Release v1.0.3

Version bump `1.0.2` → `1.0.3`.

### Included since v1.0.2
- **fix:** use real newlines for the signature separator in `gh` command bodies (#5). The separator used the literal 4-char string `\n\n`, but bash does not interpret `\n` inside a quoted `--body` argument, so `gh` received the literal characters and GitHub rendered them verbatim. Now real newlines are used, applied to all `gh` commands (`pr`/`issue create`, `pr`/`issue comment`, `pr review`).

### Release steps after merge
- [x] Tag `v1.0.3` on the merge commit (and backfill historical tags)
- [x] `npm publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)